### PR TITLE
Update Rust Toolchain to 1.89.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,12 @@ jobs:
         restore-keys: |
           ${{ runner.OS }}-build-
 
-    - name: Install latest Rust nightly
+    - name: Install Rust 1.89.0
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
         components: rustc, cargo, clippy, rustfmt
-        toolchain: nightly
+        toolchain: 1.89.0
         override: true
         target: ${{ matrix.job.target }}
 
@@ -89,8 +89,8 @@ jobs:
     - name: Add $HOME/.cargo/bin to PATH (self-hosted runners only)
       run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       if: matrix.job.runs_on == 'self-hosted'
-    - name: Use Rust 1.87.0 with target ${{ matrix.job.target }}
-      run: rustup override set 1.87.0-${{ matrix.job.target }}
+    - name: Use Rust 1.89.0 with target ${{ matrix.job.target }}
+      run: rustup override set 1.89.0-${{ matrix.job.target }}
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
     - name: Build in release mode
@@ -197,8 +197,8 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v4
-      - name: Use Rust 1.87.0
-        run: rustup override set 1.87.0
+      - name: Use Rust 1.89.0
+        run: rustup override set 1.89.0
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-edit
         run: cargo install cargo-edit
@@ -255,8 +255,8 @@ jobs:
     if: startsWith(github.event.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4
-      - name: Use Rust 1.87.0 with target x86_64-unknown-linux-gnu
-        run: rustup override set 1.87.0-x86_64-unknown-linux-gnu
+      - name: Use Rust 1.89.0 with target x86_64-unknown-linux-gnu
+        run: rustup override set 1.89.0-x86_64-unknown-linux-gnu
       - uses: Swatinem/rust-cache@v2
       - name: Publish to Crates.io
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -25,5 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: 1.89.0
+          components: rustfmt, clippy
       - run: cargo install cargo-insta
       - run: cargo build

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.89.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This pull request updates the CI configuration and setup files for the Rust toolchain to the latest stable version, 1.89.0. The changes include:

- Modified the GitHub Actions workflow `.github/workflows/ci.yml` to install Rust 1.89.0 and set it up as the override for the right targets.
- Updated references from the previous Rust version (1.87.0) to the new version in multiple steps within the CI workflow file.
- Added a new file `rust-toolchain.toml` to explicitly declare the toolchain version and required components like `rustfmt` and `clippy`.
- Adjusted the workflow `.github/workflows/copilot-setup-steps.yml` to also use Rust 1.89.0 for consistency across different build and setup steps.

These changes ensure that the project builds and tests are using the latest stable Rust version, potentially improving performance and accessing new language features.

---

> This pull request was co-created with Cosine Genie

Original Task: [csvmd/k4as6svxzcsk](https://cosine.sh/timrogers/csvmd/task/k4as6svxzcsk)
Author: Tim Rogers
